### PR TITLE
Update text explaining collision shapes

### DIFF
--- a/getting_started/introduction/godot_design_philosophy.rst
+++ b/getting_started/introduction/godot_design_philosophy.rst
@@ -52,8 +52,8 @@ structure matches the game's design.
 Also note that Godot offers many different types of objects called
 nodes, each with a specific purpose. Nodes are part of a tree and always
 inherit from their parents up to the Node class. Although the engine
-does feature components like collision shapes, they're the
-exception, not the norm.
+does feature components like collision shapes which share their state
+upwards to their parents rather than downwards, they're the exception, not the norm.
 
 |image1|
 


### PR DESCRIPTION
Updated the text to give additional context about why collision shapes are the exception and not the norm.

Resolves #5305

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
